### PR TITLE
Update ArgRead instance to allow "f" symbol for Bools

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# HEAD
+
+- Allow False as a default value for Bool arguments
+
 # 0.3.0
 
 - Simplify API

--- a/src/Options/Declarative.hs
+++ b/src/Options/Declarative.hs
@@ -112,6 +112,7 @@ instance ArgRead String where
 
 instance ArgRead Bool where
     argRead Nothing = Just False
+    argRead (Just "f") = Just False
     argRead (Just "t") = Just True
     argRead _ = Nothing
 


### PR DESCRIPTION
Add the possibility to define a False value by default for a Flag in addition to the True value.
